### PR TITLE
Improves market observer logging

### DIFF
--- a/market/market.go
+++ b/market/market.go
@@ -53,15 +53,15 @@ func runMarket(storage storage.Market, p market.Provider) error {
 	if err != nil {
 		return errors.E(err, "GetData")
 	}
-	var saveErrs = 0
+	results := make(map[string]int)
 	for _, result := range data {
-		err = storage.SaveTicker(result, marketProviders)
+		res, err := storage.SaveTicker(result, marketProviders)
+		results[string(res)]++
 		if err != nil {
-			saveErrs++
-			logger.Error(errors.E(err, "SaveTicker",
-				errors.Params{"result": result}))
+			logger.Error(errors.E(err, "SaveTicker", errors.Params{"result": result}))
 		}
 	}
-	logger.Info("Market data result", logger.Params{"markets": len(data), "provider": p.GetId(), "failed": saveErrs})
+
+	logger.Info("Market data result", logger.Params{"markets": len(data), "provider": p.GetId(), "results": results})
 	return nil
 }

--- a/market/rates.go
+++ b/market/rates.go
@@ -54,9 +54,7 @@ func runRate(storage storage.Market, p rate.Provider) error {
 	if err != nil {
 		return errors.E(err, "FetchLatestRates")
 	}
-	if len(rates) > 0 {
-		storage.SaveRates(rates, rateProviders)
-		logger.Info("Market rates", logger.Params{"rates": len(rates), "provider": p.GetId()})
-	}
+	results := storage.SaveRates(rates, rateProviders)
+	logger.Info("Done fetching latest rates", logger.Params{"numFetchedRates": len(rates), "provider": p.GetId(), "results": results})
 	return nil
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -5,6 +5,14 @@ import (
 	"github.com/trustwallet/watchmarket/pkg/watchmarket"
 )
 
+type SaveResult string
+const(
+	SaveResultSuccess                      SaveResult = "Success"
+	SaveResultStorageFailure               SaveResult = "StorageFailure"
+	SaveResultSkippedLowPriority           SaveResult = "SkippedLowPriority"
+	SaveResultSkippedLowPriorityOrOutdated SaveResult = "SkippedLowPriorityOrOutdated"
+)
+
 type Storage struct {
 	redis.Redis
 }
@@ -15,8 +23,8 @@ func New() *Storage {
 }
 
 type Market interface {
-	SaveTicker(coin *watchmarket.Ticker, pl ProviderList) error
+	SaveTicker(coin *watchmarket.Ticker, pl ProviderList) (SaveResult, error)
 	GetTicker(coin, token string) (*watchmarket.Ticker, error)
-	SaveRates(rates watchmarket.Rates, pl ProviderList)
+	SaveRates(rates watchmarket.Rates, pl ProviderList) map[SaveResult]int
 	GetRate(currency string) (*watchmarket.Rate, error)
 }


### PR DESCRIPTION
#### Problem
This solves multiple problems:
1. fixed error reporting: currently when we decide to skip saving a record due to priority we log an `ERROR`. This is wrong
1. noisy logs: currently for each record we skip due to its priority we create a log statement. That's thousands of log statements. This cleans these log statements up

#### Solution
Don't log errors for skipped records and change the contract to provide information about how many records were skipped and why.

#### Testing
`make start` and the new log output is much more crisp (prior there were thousands of `ERROR` logs):

```
# Rates
INFO[0016] Done fetching latest rates                    numFetchedRates=6863 provider=coingecko results="map[SkippedLowPriority:4 SkippedLowPriorityOrOutdated:879 StorageFailure:95 Success:5885]"

# Markets
INFO[0026] Market data result                            markets=6861 provider=coingecko results="map[SkippedLowPriority:3 SkippedLowPriorityOrOutdated:182 Success:6676]"
```

### TESTING
Tested manually. We currently have no UTs for this an no mocking framework in place. Should be added in the future.