### PR TITLE
Fixes CoinGecko handling of coins  with null or 0 prices (#21)

### DIFF
--- a/market/rate/coingecko/coingecko.go
+++ b/market/rate/coingecko/coingecko.go
@@ -41,7 +41,7 @@ func (c *Coingecko) FetchLatestRates() (rates watchmarket.Rates, err error) {
 func normalizeRates(coinPrices coingecko.CoinPrices, provider string) (rates watchmarket.Rates) {
 	for _, price := range coinPrices {
 		rate := 0.0
-		if price.CurrentPrice > 0 {
+		if price.CurrentPrice != 0 {
 			rate = 1.0 / price.CurrentPrice
 		}
 		rates = append(rates, watchmarket.Rate{

--- a/market/rate/coingecko/coingecko.go
+++ b/market/rate/coingecko/coingecko.go
@@ -40,9 +40,13 @@ func (c *Coingecko) FetchLatestRates() (rates watchmarket.Rates, err error) {
 
 func normalizeRates(coinPrices coingecko.CoinPrices, provider string) (rates watchmarket.Rates) {
 	for _, price := range coinPrices {
+		rate := 0.0
+		if price.CurrentPrice > 0 {
+			rate = 1.0 / price.CurrentPrice
+		}
 		rates = append(rates, watchmarket.Rate{
 			Currency:  strings.ToUpper(price.Symbol),
-			Rate:      1.0 / price.CurrentPrice,
+			Rate:      rate,
 			Timestamp: price.LastUpdated.Unix(),
 			Provider:  provider,
 		})

--- a/market/rate/coingecko/coingecko_test.go
+++ b/market/rate/coingecko/coingecko_test.go
@@ -49,6 +49,23 @@ func Test_normalizeRates(t *testing.T) {
 				watchmarket.Rate{Currency: "CREP", Rate: 1 / 110.02, Timestamp: 123, Provider: id},
 			},
 		},
+		{
+			"test normalize 0 rates",
+			coingecko.CoinPrices{
+				{
+					Symbol:       "cUSDC",
+					CurrentPrice: 0.0,
+				},
+				{
+					Symbol:       "cREP",
+					CurrentPrice: 110.02,
+				},
+			},
+			watchmarket.Rates{
+				watchmarket.Rate{Currency: "CUSDC", Rate: 0.0, Timestamp: 123, Provider: id},
+				watchmarket.Rate{Currency: "CREP", Rate: 1 / 110.02, Timestamp: 123, Provider: id},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/market/rate/coingecko/coingecko_test.go
+++ b/market/rate/coingecko/coingecko_test.go
@@ -66,6 +66,23 @@ func Test_normalizeRates(t *testing.T) {
 				watchmarket.Rate{Currency: "CREP", Rate: 1 / 110.02, Timestamp: 123, Provider: id},
 			},
 		},
+		{
+			"test normalize negative rates (you never know...)",
+			coingecko.CoinPrices{
+				{
+					Symbol:       "cUSDC",
+					CurrentPrice: -5.0,
+				},
+				{
+					Symbol:       "cREP",
+					CurrentPrice: 110.02,
+				},
+			},
+			watchmarket.Rates{
+				watchmarket.Rate{Currency: "CUSDC", Rate: 1 / -5.0, Timestamp: 123, Provider: id},
+				watchmarket.Rate{Currency: "CREP", Rate: 1 / 110.02, Timestamp: 123, Provider: id},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Some coins in _CoinGecko_ have `null` or 0 rates (see data in #21 ). This sets the Watchmarket rate for such coins to zero.

@vikmeup to confirm whether a rate of 0 is actually the correct solution here.