### PR TITLE
Properly implements HTTP 404 status codes (Fixes #23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,12 @@ REST API - allows to get cached data through REST HTTP API
 
 1. Spin up a Redis instance: `docker run -it -p 6379:6379 redis`
 1. Start the app: `make start`
-  1. Explore the API: [http://localhost:8423/swagger/index.html](http://localhost:8423/swagger/index.html)
-  1. Use the API: `curl -v "http://localhost:8421/v1/market/info?coin=60" | jq .`
-1. When done run `make stop`
+   1. Explore the API: [http://localhost:8423/swagger/index.html](http://localhost:8423/swagger/index.html)
+   1. Use the API:
+      * `curl -v "http://localhost:8421/v1/market/info?coin=60" | jq .`
+      * `curl -v -X POST 'http://localhost:8421/v1/market/ticker' -H 'Content-Type: application/json' -d '{"currency":"ETH","assets":[{"type":"coin","coin":60}]}'`
+      * `curl -v "http://localhost:8421/v1/market/charts?coin=60&time_start=1574483028" | jq .`
+1. When done: `make stop`
 
 Run `make` to see a list of all available build directives.
 

--- a/api/marketdata.go
+++ b/api/marketdata.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/viper"
 	"github.com/trustwallet/blockatlas/coin"
@@ -15,6 +16,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"fmt"
 )
 
 const (
@@ -60,10 +62,14 @@ func getTickersHandler(storage storage.Market) func(c *gin.Context) {
 			ginutils.ErrorResponse(c).Message(err.Error()).Render()
 			return
 		}
+
 		rate, err := storage.GetRate(strings.ToUpper(md.Currency))
-		if err != nil {
+		if errors.Is(err, watchmarket.ErrNotFound) {
+			ginutils.RenderError(c, http.StatusNotFound, fmt.Sprintf("Currency %s not found", md.Currency))
+			return
+		} else if err != nil {
 			logger.Error(err, "Failed to retrieve rate", logger.Params{"currency": md.Currency})
-			ginutils.RenderError(c, http.StatusInternalServerError, "Failed to retrieve rate")
+			ginutils.RenderError(c, http.StatusInternalServerError, fmt.Sprintf("Failed to get rate for %s", md.Currency))
 			return
 		}
 
@@ -78,8 +84,13 @@ func getTickersHandler(storage storage.Market) func(c *gin.Context) {
 			}
 			r, err := storage.GetTicker(coinObj.Symbol, strings.ToUpper(coinRequest.TokenId))
 			if err != nil {
-				// TODO: either fail the request or signal to requester that ticker for coin couldn't be retrieved
-				logger.Error(err, "Failed to retrieve ticker", logger.Params{"coin": coinObj.Symbol, "currency": md.Currency})
+				if errors.Is(err, watchmarket.ErrNotFound) {
+					logger.Warn("Ticker not found", logger.Params{"coin": coinObj.Symbol, "token": coinRequest.TokenId})
+				} else if err != nil {
+					logger.Error(err, "Failed to retrieve ticker", logger.Params{"coin": coinObj.Symbol, "token": coinRequest.TokenId})
+					ginutils.RenderError(c, http.StatusInternalServerError, "Failed to retrieve tickers")
+					return
+				}
 				continue
 			}
 			if r.Price.Currency != watchmarket.DefaultCurrency {

--- a/api/marketdata.go
+++ b/api/marketdata.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"errors"
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/viper"
 	"github.com/trustwallet/blockatlas/coin"
@@ -64,7 +63,7 @@ func getTickersHandler(storage storage.Market) func(c *gin.Context) {
 		}
 
 		rate, err := storage.GetRate(strings.ToUpper(md.Currency))
-		if errors.Is(err, watchmarket.ErrNotFound) {
+		if err == watchmarket.ErrNotFound {
 			ginutils.RenderError(c, http.StatusNotFound, fmt.Sprintf("Currency %s not found", md.Currency))
 			return
 		} else if err != nil {
@@ -84,7 +83,7 @@ func getTickersHandler(storage storage.Market) func(c *gin.Context) {
 			}
 			r, err := storage.GetTicker(coinObj.Symbol, strings.ToUpper(coinRequest.TokenId))
 			if err != nil {
-				if errors.Is(err, watchmarket.ErrNotFound) {
+				if err == watchmarket.ErrNotFound {
 					logger.Warn("Ticker not found", logger.Params{"coin": coinObj.Symbol, "token": coinRequest.TokenId})
 				} else if err != nil {
 					logger.Error(err, "Failed to retrieve ticker", logger.Params{"coin": coinObj.Symbol, "token": coinRequest.TokenId})

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ pool:
   vmImage: 'Ubuntu 16.04'
 
 variables:
-  GOVERSION: '1.13'
+  GOVERSION: '1.13.6'
 
 jobs:
   - job: environment

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ pool:
   vmImage: 'Ubuntu 16.04'
 
 variables:
-  GOVERSION: '1.13.6'
+  GOVERSION: '1.13'
 
 jobs:
   - job: environment

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/getsentry/sentry-go v0.5.1
 	github.com/gin-gonic/gin v1.5.0
+	github.com/go-redis/redis v6.15.6+incompatible
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.4.0

--- a/pkg/watchmarket/errors.go
+++ b/pkg/watchmarket/errors.go
@@ -1,0 +1,9 @@
+package watchmarket
+
+import "errors"
+
+var (
+	ErrNotFound = errNotFound()
+)
+
+func errNotFound() error { return errors.New("record does not exist") }

--- a/redis/hmap.go
+++ b/redis/hmap.go
@@ -1,0 +1,55 @@
+package redis
+
+import (
+	"encoding/json"
+	"github.com/go-redis/redis"
+	"github.com/trustwallet/watchmarket/pkg/watchmarket"
+)
+
+func (db *Redis) GetAllHM(entity string) (map[string]string, error) {
+	cmd := db.client.HGetAll(entity)
+	if cmd.Err() == redis.Nil {
+		return nil, watchmarket.ErrNotFound
+	} else if cmd.Err() != nil {
+		return nil, cmd.Err()
+	}
+	return cmd.Val(), nil
+}
+
+func (db *Redis) GetHMValue(entity, key string, value interface{}) error {
+	cmd := db.client.HMGet(entity, key)
+	if cmd.Err() == redis.Nil {
+		return watchmarket.ErrNotFound
+	} else if cmd.Err() != nil {
+		return cmd.Err()
+	}
+	val, ok := cmd.Val()[0].(string)
+	if !ok {
+		return watchmarket.ErrNotFound
+	}
+	err := json.Unmarshal([]byte(val), value)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (db *Redis) AddHM(entity, key string, value interface{}) error {
+	j, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	cmd := db.client.HMSet(entity, map[string]interface{}{key: j})
+	if cmd.Err() != nil {
+		return cmd.Err()
+	}
+	return nil
+}
+
+func (db *Redis) DeleteHM(entity, key string) error {
+	cmd := db.client.HDel(entity, key)
+	if cmd.Err() != nil {
+		return cmd.Err()
+	}
+	return nil
+}

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -1,0 +1,65 @@
+package redis
+
+import (
+	"encoding/json"
+	"github.com/go-redis/redis"
+	"github.com/trustwallet/watchmarket/pkg/watchmarket"
+)
+
+type Redis struct {
+	client *redis.Client
+}
+
+func (db *Redis) Init(host string) error {
+	options, err := redis.ParseURL(host)
+	if err != nil {
+		return err
+	}
+	client := redis.NewClient(options)
+	if err := client.Ping().Err(); err != nil {
+		return err
+	}
+	db.client = client
+	return nil
+}
+
+func (db *Redis) GetValue(key string, value interface{}) error {
+	cmd := db.client.Get(key)
+	if cmd.Err() == redis.Nil {
+		return watchmarket.ErrNotFound
+	} else if cmd.Err() != nil {
+		return cmd.Err()
+	}
+	err := json.Unmarshal([]byte(cmd.Val()), value)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (db *Redis) Add(key string, value interface{}) error {
+	j, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	cmd := db.client.Set(key, j, 0)
+	if cmd.Err() != nil {
+		return cmd.Err()
+	}
+	return nil
+}
+
+func (db *Redis) Delete(key string) error {
+	cmd := db.client.Del(key)
+	if cmd.Err() != nil {
+		return cmd.Err()
+	}
+	return nil
+}
+
+func (db *Redis) IsReady() bool {
+	if db.client == nil {
+		return false
+	}
+	return db.client.Ping().Err() == nil
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,8 +1,8 @@
 package storage
 
 import (
-	"github.com/trustwallet/blockatlas/pkg/storage/redis"
 	"github.com/trustwallet/watchmarket/pkg/watchmarket"
+	"github.com/trustwallet/watchmarket/redis"
 )
 
 type Storage struct {


### PR DESCRIPTION
### Problem
We currently are not consistently transparent to users as to why their requests fail. As an example, a request for a coin named "i do not exist" will result in a HTTP 500 error, leading clients to think that this was an internal server error.
This should be a HTTP 404 to signal to clients that there is no record for a coin called "i do not exist".

We currently use a thin layer around the Go Redis client from [Blockatlas](github.com/trustwallet/blockatlas/pkg/storage/redis). This implementation is flawed as it loses granularity around NotFoundErrors.

### Solution
Instead of patching Blockatlas' implementation and using the Blockatlas error definitions this change is moving the Blockatlas wrapper into Watchmarket while improving the error handling. Also using new Watchmarket errors definitions.

Further rationale for moving the thin Redis wrapper to Watchmarket is that in the future we are planning on not relying as heavily on Redis hashmaps and using flat KVs instead.

### Testing
Manually tested. Should be covered in tests in the future.