### PR TITLE
Separates concerns in app bootstrap

### DIFF
--- a/cmd/market_observer/main.go
+++ b/cmd/market_observer/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/spf13/viper"
+	"github.com/trustwallet/blockatlas/pkg/logger"
 	"github.com/trustwallet/watchmarket/internal"
 	"github.com/trustwallet/watchmarket/market"
 	"github.com/trustwallet/watchmarket/storage"
@@ -11,12 +13,16 @@ const (
 )
 
 var (
-	confPath string
 	cache    *storage.Storage
 )
 
 func init() {
-	_, confPath, _, cache = internal.InitAPIWithRedis("", defaultConfigPath)
+	_, confPath := internal.ParseArgs("", defaultConfigPath)
+	internal.InitConfig(confPath)
+	logger.InitLogger()
+
+	redisHost := viper.GetString("storage.redis")
+	cache = internal.InitRedis(redisHost)
 }
 
 func main() {

--- a/cmd/swagger_api/main.go
+++ b/cmd/swagger_api/main.go
@@ -1,47 +1,41 @@
 package main
 
 import (
+	sentrygin "github.com/getsentry/sentry-go/gin"
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/viper"
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"github.com/swaggo/gin-swagger/swaggerFiles"
-	"github.com/trustwallet/blockatlas/pkg/ginutils"
-	"github.com/trustwallet/watchmarket/api"
+	"github.com/trustwallet/blockatlas/pkg/logger"
 	_ "github.com/trustwallet/watchmarket/docs"
 	"github.com/trustwallet/watchmarket/internal"
+	"net/http"
 )
 
 const (
 	defaultPort       = "8423"
 	defaultConfigPath = "../../config.yml"
-	allPlatforms      = "all"
 )
 
 var (
 	port, confPath string
-	sg             *gin.HandlerFunc
+	engine         *gin.Engine
 )
 
 func init() {
-	port, confPath, sg = internal.InitAPI(defaultPort, defaultConfigPath)
+	port, confPath = internal.ParseArgs(defaultPort, defaultConfigPath)
+	tmp := sentrygin.New(sentrygin.Options{}); sg := &tmp
+	internal.InitConfig(confPath)
+	logger.InitLogger()
+	engine = internal.InitEngine(sg, viper.GetString("gin.mode"))
+
 }
 
 func main() {
-	gin.SetMode(viper.GetString("gin.mode"))
-
-	engine := gin.New()
-	engine.Use(ginutils.CheckReverseProxy, *sg)
-	engine.Use(ginutils.CORSMiddleware())
-
-	engine.OPTIONS("/*path", ginutils.CORSMiddleware())
-	engine.GET("/", api.GetRoot)
-	engine.GET("/status", func(c *gin.Context) {
-		ginutils.RenderSuccess(c, map[string]interface{}{
-			"status": true,
-		})
+	logger.Info("Loading Swagger API")
+	engine.GET("/", func(c *gin.Context) {
+		c.Redirect(http.StatusMovedPermanently, "swagger/index.html")
 	})
-
 	engine.GET("swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
-
 	internal.SetupGracefulShutdown(port, engine)
 }


### PR DESCRIPTION
Rationale: app bootstrap is currently highly coupled to specific implementations of the app server, web framework, cache implementation. This prevents from bootstrapping with any alternative implementations of these. We will want to provide alternative implementations of server and cache for instance for functional testing.

Highlights:
* `market_observer` bootstrap invokes `internal.InitAPIWithRedis` despite not serving an API - refactored to instead leverage a new `internal.InitRedis` function
* swagger API and market API use `internal.InitAPI` and `internal.InitAPIWithRedis` apis. These are mostly equivalent/redundant. Introducing a `internal.InitEngine` instead to share code
* swapper API has a dependency on `marketdata.go` to serve app root which is unnecessary
* swagger API "GET /" serves "Watchmarket API" as text. Switching to redirect "GET /" to "/swagger/index.html"