### PR TITLE
Fixed: `SaveTicker` and `SaveRates` APIs swallow errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ cmd/__debug_bin
 config_*.yml
 *.orig
 *~
+mocks
 
 ### macOS ###
 *.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,16 @@ exec:
 ## clean: Clean build files. Runs `go clean` internally.
 clean:
 	@-rm $(GOBIN)/$(PROJECT_NAME) 2> /dev/null
+	@-rm -rf mocks
 	@-$(MAKE) go-clean
 
+## generate-mocks: Creates mockfiles.
+generate-mocks:
+	@-$(GOBIN)/mockery -dir storage -name DB
+	@-$(GOBIN)/mockery -dir storage -name ProviderList
+
 ## test: Run all unit tests.
-test: go-test
+test: go-install-mockery generate-mocks go-test
 
 ## functional: Run all functional tests.
 functional: go-functional
@@ -99,7 +105,7 @@ integration: go-integration
 fmt: go-fmt
 
 ## govet: Run go vet.
-govet: go-vet
+govet: go-install-mockery generate-mocks go-vet
 
 ## golint: Run golint.
 golint: go-lint
@@ -143,7 +149,7 @@ go-generate:
 	GOBIN=$(GOBIN) go generate $(generate)
 
 go-get:
-	@echo "  >  Checking if there is any missing dependencies..."
+	@echo "  >  Checking if there are any missing dependencies..."
 	GOBIN=$(GOBIN) go get cmd/... $(get)
 
 go-install:
@@ -176,6 +182,10 @@ go-gen-docs:
 go-vet:
 	@echo "  >  Running go vet"
 	GOBIN=$(GOBIN) go vet ./...
+
+go-install-mockery:
+	@echo "  >  Installing mockery"
+	GOBIN=$(GOBIN) go get github.com/vektra/mockery/.../
 
 go-lint:
 	@echo "  >  Running golint"

--- a/api/marketdata.go
+++ b/api/marketdata.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/spf13/viper"
 	"github.com/trustwallet/blockatlas/coin"
@@ -15,7 +16,6 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
-	"fmt"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,9 @@ require (
 	github.com/go-redis/redis v6.15.6+incompatible
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/viper v1.6.2
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.5.1
 	github.com/swaggo/gin-swagger v1.2.0
 	github.com/swaggo/swag v1.6.5
 	github.com/trustwallet/blockatlas v1.0.37
+	github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5 // indirect
 )

--- a/internal/init.go
+++ b/internal/init.go
@@ -6,6 +6,7 @@ import (
 	"github.com/trustwallet/blockatlas/pkg/ginutils"
 	"github.com/trustwallet/blockatlas/pkg/logger"
 	"github.com/trustwallet/watchmarket/config"
+	"github.com/trustwallet/watchmarket/redis"
 	"github.com/trustwallet/watchmarket/storage"
 	"path/filepath"
 )
@@ -22,8 +23,9 @@ func ParseArgs(defaultPort, defaultConfigPath string) (string, string) {
 	return port, confPath
 }
 
+
 func InitRedis(host string) *storage.Storage {
-	cache := storage.New()
+	cache := &storage.Storage{DB: &redis.Redis{}}
 	err := cache.Init(host)
 	if err != nil {
 		logger.Fatal(err)

--- a/storage/market_test.go
+++ b/storage/market_test.go
@@ -1,0 +1,343 @@
+package storage
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/trustwallet/watchmarket/mocks"
+	"github.com/trustwallet/watchmarket/pkg/watchmarket"
+	"testing"
+	"time"
+)
+
+func TestSaveTickerWhenTickerDoesntExist(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockProviderList := &mocks.ProviderList{}
+	mockTicker := &watchmarket.Ticker{
+		Coin:       10,
+		CoinName:   "myTestCoin",
+		TokenId:    "myTestTokenId",
+		CoinType:   "myTestCoinType",
+		Price:      watchmarket.TickerPrice{},
+		LastUpdate: time.Time{},
+	}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.AnythingOfType("**watchmarket.Ticker")).Return(watchmarket.ErrNotFound)
+	mockDb.On("AddHM", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.AnythingOfType("*watchmarket.Ticker")).Return(nil)
+
+	subject := &Storage{mockDb}
+
+	res ,err := subject.SaveTicker(mockTicker, mockProviderList)
+
+	assert.Nil(t, err)
+	assert.Equal(t, SaveResultSuccess, res)
+}
+
+func TestSaveTickerWhenTickerDoesntExistAndDbFails(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockProviderList := &mocks.ProviderList{}
+	mockTicker := &watchmarket.Ticker{
+		Coin:       10,
+		CoinName:   "myTestCoin",
+		TokenId:    "myTestTokenId",
+		CoinType:   "myTestCoinType",
+		Price:      watchmarket.TickerPrice{},
+		LastUpdate: time.Time{},
+	}
+	addHMErr := errors.New("boom")
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.AnythingOfType("**watchmarket.Ticker")).Return(watchmarket.ErrNotFound)
+	mockDb.On("AddHM", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.AnythingOfType("*watchmarket.Ticker")).Return(addHMErr)
+
+	subject := &Storage{mockDb}
+
+	res, err := subject.SaveTicker(mockTicker, mockProviderList)
+
+	assert.Equal(t, addHMErr, err)
+	assert.Equal(t, SaveResultStorageFailure, res)
+}
+
+func TestSaveTickerWhenTickerRetrievalFails(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockProviderList := &mocks.ProviderList{}
+	mockTicker := &watchmarket.Ticker{
+		Coin:       10,
+		CoinName:   "myTestCoin",
+		TokenId:    "myTestTokenId",
+		CoinType:   "myTestCoinType",
+		Price:      watchmarket.TickerPrice{},
+		LastUpdate: time.Time{},
+	}
+	retrievalErr := errors.New("boom")
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.AnythingOfType("**watchmarket.Ticker")).Return(retrievalErr)
+
+	subject := &Storage{mockDb}
+
+	res, err := subject.SaveTicker(mockTicker, mockProviderList)
+
+	assert.Equal(t, retrievalErr, err)
+	assert.Equal(t, SaveResultStorageFailure, res)
+}
+
+func TestSaveTickerWhenTickerExistsAndPriorityTooLow(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockProviderList := &mocks.ProviderList{}
+	mockProviderList.On("GetPriority", "myNewTestProvider").Return(10)
+	mockProviderList.On("GetPriority", "myOldTestProvider").Return(0)
+	mockTicker := &watchmarket.Ticker{
+		CoinName:   "myTestCoin",
+		TokenId:    "myTestTokenId",
+		Price:      watchmarket.TickerPrice{
+			Provider:  "myNewTestProvider",
+		},
+		LastUpdate: time.Now(),
+	}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.MatchedBy(func(value interface{}) bool {
+		*value.(**watchmarket.Ticker) = &watchmarket.Ticker{
+			CoinName:   "myTestCoin",
+			TokenId:    "myTestTokenId",
+			Price:      watchmarket.TickerPrice{
+				Provider:  "myOldTestProvider",
+			},
+			LastUpdate: time.Now(),
+		}
+		return true
+	})).Return(nil)
+
+	subject := &Storage{mockDb}
+
+	res, err := subject.SaveTicker(mockTicker, mockProviderList)
+
+	assert.Nil(t, err)
+	assert.Equal(t, SaveResultSkippedLowPriority, res)
+}
+
+func TestSaveTickerWhenTickerExistsAndOutdated(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockProviderList := &mocks.ProviderList{}
+	mockProviderList.On("GetPriority", "myNewTestProvider").Return(0)
+	mockProviderList.On("GetPriority", "myOldTestProvider").Return(10)
+	mockTicker := &watchmarket.Ticker{
+		CoinName:   "myTestCoin",
+		TokenId:    "myTestTokenId",
+		Price:      watchmarket.TickerPrice{
+			Provider:  "myNewTestProvider",
+		},
+		LastUpdate: time.Now(),
+	}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.MatchedBy(func(value interface{}) bool {
+		*value.(**watchmarket.Ticker) = &watchmarket.Ticker{
+			CoinName:   "myTestCoin",
+			TokenId:    "myTestTokenId",
+			Price:      watchmarket.TickerPrice{
+				Provider:  "myOldTestProvider",
+			},
+			LastUpdate: time.Now(),
+		}
+		return true
+	})).Return(nil)
+
+	subject := &Storage{mockDb}
+
+	res, err := subject.SaveTicker(mockTicker, mockProviderList)
+
+	assert.Nil(t, err)
+	assert.Equal(t, SaveResultSkippedLowPriorityOrOutdated, res)
+}
+
+func TestGetTickerNominal(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.AnythingOfType("**watchmarket.Ticker")).Return(nil)
+
+	subject := &Storage{mockDb}
+
+	_, err := subject.GetTicker("myTestCoin", "myTestTokenId")
+
+	assert.Nil(t, err)
+}
+
+func TestGetTickerWithoutToken(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN", mock.AnythingOfType("**watchmarket.Ticker")).Return(nil)
+
+	subject := &Storage{mockDb}
+
+	_, err := subject.GetTicker("myTestCoin", "")
+
+	assert.Nil(t, err)
+}
+
+func TestGetTickerError(t *testing.T) {
+	dbErr := errors.New("boom")
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_QUOTES", "MYTESTCOIN_MYTESTTOKENID", mock.AnythingOfType("**watchmarket.Ticker")).Return(dbErr)
+
+	subject := &Storage{mockDb}
+
+	_, err := subject.GetTicker("myTestCoin", "myTestTokenId")
+
+	assert.Equal(t, dbErr, err)
+}
+
+func TestGetRateNominal(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("**watchmarket.Rate")).Return(nil)
+
+	subject := &Storage{mockDb}
+
+	_, err := subject.GetRate("myTestCurrency")
+
+	assert.Nil(t, err)
+}
+
+func TestGetRateError(t *testing.T) {
+	dbErr := errors.New("boom")
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("**watchmarket.Rate")).Return(dbErr)
+
+	subject := &Storage{mockDb}
+
+	_, err := subject.GetRate("myTestCurrency")
+
+	assert.Equal(t, dbErr, err)
+}
+
+func TestSaveRatesNoExistingRate(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("**watchmarket.Rate")).Return(watchmarket.ErrNotFound)
+	mockDb.On("AddHM", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("*watchmarket.Rate")).Return(nil)
+	mockRates := watchmarket.Rates{}
+	mockRates = append(mockRates, watchmarket.Rate{Currency: "myTestCurrency",})
+	mockProviderList := &mocks.ProviderList{}
+
+	subject := &Storage{mockDb}
+
+	results := subject.SaveRates(mockRates, mockProviderList)
+
+	assert.Len(t, results, 1)
+	assert.Contains(t, results, SaveResultSuccess)
+	assert.Equal(t, results[SaveResultSuccess], 1)
+}
+
+func TestSaveRatesExistingRate(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.MatchedBy(func(value interface{}) bool {
+		*value.(**watchmarket.Rate) = &watchmarket.Rate{
+			Currency:         "myTestCurrency",
+			Provider:         "myOldTestProvider",
+			Timestamp:        0,
+		}
+		return true
+	})).Return(nil)
+	mockDb.On("AddHM", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("*watchmarket.Rate")).Return(nil)
+	mockRates := watchmarket.Rates{}
+	mockRates = append(mockRates, watchmarket.Rate{
+		Currency:         "myTestCurrency",
+		Provider:         "myNewTestProvider",
+		Timestamp:        10,
+	})
+	mockProviderList := &mocks.ProviderList{}
+	mockProviderList.On("GetPriority", "myNewTestProvider").Return(0)
+	mockProviderList.On("GetPriority", "myOldTestProvider").Return(10)
+
+	subject := &Storage{mockDb}
+
+	results := subject.SaveRates(mockRates, mockProviderList)
+
+	assert.Len(t, results, 1)
+	assert.Contains(t, results, SaveResultSuccess)
+	assert.Equal(t, results[SaveResultSuccess], 1)
+}
+
+func TestSaveRatesExistingRateNewRateLowPriority(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.MatchedBy(func(value interface{}) bool {
+		*value.(**watchmarket.Rate) = &watchmarket.Rate{
+			Currency:         "myTestCurrency",
+			Provider:         "myOldTestProvider",
+			Timestamp:        0,
+		}
+		return true
+	})).Return(nil)
+	mockDb.On("AddHM", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("*watchmarket.Rate")).Return(nil)
+	mockRates := watchmarket.Rates{}
+	mockRates = append(mockRates, watchmarket.Rate{
+		Currency:         "myTestCurrency",
+		Provider:         "myNewTestProvider",
+		Timestamp:        10,
+	})
+	mockProviderList := &mocks.ProviderList{}
+	mockProviderList.On("GetPriority", "myNewTestProvider").Return(10)
+	mockProviderList.On("GetPriority", "myOldTestProvider").Return(0)
+
+	subject := &Storage{mockDb}
+
+	results := subject.SaveRates(mockRates, mockProviderList)
+
+	assert.Len(t, results, 1)
+	assert.Contains(t, results, SaveResultSkippedLowPriority)
+	assert.Equal(t, results[SaveResultSkippedLowPriority], 1)
+}
+
+func TestSaveRatesExistingRateNewRateOutdated(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.MatchedBy(func(value interface{}) bool {
+		*value.(**watchmarket.Rate) = &watchmarket.Rate{
+			Currency:         "myTestCurrency",
+			Provider:         "myOldTestProvider",
+			Timestamp:        10,
+		}
+		return true
+	})).Return(nil)
+	mockDb.On("AddHM", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("*watchmarket.Rate")).Return(nil)
+	mockRates := watchmarket.Rates{}
+	mockRates = append(mockRates, watchmarket.Rate{
+		Currency:         "myTestCurrency",
+		Provider:         "myNewTestProvider",
+		Timestamp:        0,
+	})
+	mockProviderList := &mocks.ProviderList{}
+	mockProviderList.On("GetPriority", "myNewTestProvider").Return(0)
+	mockProviderList.On("GetPriority", "myOldTestProvider").Return(0)
+
+	subject := &Storage{mockDb}
+
+	results := subject.SaveRates(mockRates, mockProviderList)
+
+	assert.Len(t, results, 1)
+	assert.Contains(t, results, SaveResultSkippedLowPriorityOrOutdated)
+	assert.Equal(t, results[SaveResultSkippedLowPriorityOrOutdated], 1)
+}
+
+func TestSaveRatesDbSaveFails(t *testing.T) {
+	mockDb := &mocks.DB{}
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("**watchmarket.Rate")).Return(watchmarket.ErrNotFound)
+	dbSaveFailure := errors.New("boom")
+	mockDb.On("AddHM", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("*watchmarket.Rate")).Return(dbSaveFailure)
+	mockRates := watchmarket.Rates{}
+	mockRates = append(mockRates, watchmarket.Rate{Currency: "myTestCurrency",})
+	mockProviderList := &mocks.ProviderList{}
+
+	subject := &Storage{mockDb}
+
+	results := subject.SaveRates(mockRates, mockProviderList)
+
+	assert.Len(t, results, 1)
+	assert.Contains(t, results, SaveResultStorageFailure)
+	assert.Equal(t, results[SaveResultStorageFailure], 1)
+}
+func TestSaveRatesDbRetrievalFails(t *testing.T) {
+	mockDb := &mocks.DB{}
+	dbRetrievalFailure := errors.New("boom")
+	mockDb.On("GetHMValue", "ATLAS_MARKET_RATES", "myTestCurrency", mock.AnythingOfType("**watchmarket.Rate")).Return(dbRetrievalFailure)
+	mockRates := watchmarket.Rates{}
+	mockRates = append(mockRates, watchmarket.Rate{Currency: "myTestCurrency",})
+	mockProviderList := &mocks.ProviderList{}
+
+	subject := &Storage{mockDb}
+
+	results := subject.SaveRates(mockRates, mockProviderList)
+
+	assert.Len(t, results, 1)
+	assert.Contains(t, results, SaveResultStorageFailure)
+	assert.Equal(t, results[SaveResultStorageFailure], 1)
+
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"github.com/trustwallet/watchmarket/pkg/watchmarket"
-	"github.com/trustwallet/watchmarket/redis"
 )
 
 type SaveResult string
@@ -14,12 +13,13 @@ const(
 )
 
 type Storage struct {
-	redis.Redis
+	DB
 }
 
-func New() *Storage {
-	s := new(Storage)
-	return s
+type DB interface {
+	GetHMValue(entity, key string, value interface{}) error
+	AddHM(entity, key string, value interface{}) error
+	Init(host string) error
 }
 
 type Market interface {


### PR DESCRIPTION
* Fixes swallowing of errors of `SaveTicker` and `SaveRates` API
* Adds unit tests for Market using testify/mock and mockery.
* Creates HTML test coverage report


market.go test coverage:
before: 0%
after: 100%