### PR TITLE
Integrates with codecov.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ go-clean:
 
 go-test:
 	@echo "  >  Running unit tests"
-	GOBIN=$(GOBIN) go test -cover -race -v ./...
+	GOBIN=$(GOBIN) go test -coverprofile=coverage.txt -cover -race -v ./...
 
 go-functional:
 	@echo "  >  Running functional tests"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Is under development at master branch. Was migrated from [Blockatlas](https://github.com/trustwallet/blockatlas) at version/blockatlas branch
 
 [![Build Status](https://dev.azure.com/TrustWallet/WatchMarket/_apis/build/status/trustwallet.watchmarket?branchName=master)](https://dev.azure.com/TrustWallet/WatchMarket/_build/latest?definitionId=45&branchName=master)
+[![codecov](https://codecov.io/gh/trustwallet/watchmarket/branch/develop/graph/badge.svg)](https://codecov.io/gh/trustwallet/watchmarket)
 
 **IMPORTANT!**
 Is under development at master branch. Was migrated from [Blockatlas](https://github.com/trustwallet/blockatlas) at version/blockatlas branch

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,9 @@ jobs:
       - script: make test
         workingDirectory: '$(System.DefaultWorkingDirectory)'
         displayName: 'Run unit tests'
+      - script: bash <(curl -s https://codecov.io/bash) -f coverage.txt
+        workingDirectory: '$(System.DefaultWorkingDirectory)'
+        displayName: 'Upload coverage to codecov.io'
 
   - job: build
     dependsOn: environment


### PR DESCRIPTION
See https://codecov.io/gh/trustwallet/watchmarket/branch/feature%2Fcoverage for an example.

Rationale:
* go native coverage reports are not great to read
* increases emphasis on test coverage/code quality