### PR TITLE
Tests Market Observer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,10 @@ clean:
 
 ## generate-mocks: Creates mockfiles.
 generate-mocks:
-	@-$(GOBIN)/mockery -dir storage -name DB
-	@-$(GOBIN)/mockery -dir storage -name ProviderList
+	@-$(GOBIN)/mockery -dir storage -output mocks/storage -name DB
+	@-$(GOBIN)/mockery -dir storage -output mocks/storage -name ProviderList
+	@-$(GOBIN)/mockery -dir market/rate -output mocks/market/rate -name RateProvider
+	@-$(GOBIN)/mockery -dir market/market -output mocks/market/market -name MarketProvider
 
 ## test: Run all unit tests.
 test: go-install-mockery generate-mocks go-test

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/trustwallet/blockatlas/coin"
 	"github.com/trustwallet/watchmarket/internal"
-	"github.com/trustwallet/watchmarket/mocks"
+	"github.com/trustwallet/watchmarket/mocks/storage"
 	"github.com/trustwallet/watchmarket/pkg/watchmarket"
 	"github.com/trustwallet/watchmarket/storage"
 	"io"

--- a/cmd/market_observer/main.go
+++ b/cmd/market_observer/main.go
@@ -5,6 +5,16 @@ import (
 	"github.com/trustwallet/blockatlas/pkg/logger"
 	"github.com/trustwallet/watchmarket/internal"
 	"github.com/trustwallet/watchmarket/market"
+	marketprovider "github.com/trustwallet/watchmarket/market/market"
+	marketcmc "github.com/trustwallet/watchmarket/market/market/cmc"
+	marketcoingecko "github.com/trustwallet/watchmarket/market/market/coingecko"
+	marketcompound "github.com/trustwallet/watchmarket/market/market/compound"
+	marketdex "github.com/trustwallet/watchmarket/market/market/dex"
+	rateprovider "github.com/trustwallet/watchmarket/market/rate"
+	ratecmc "github.com/trustwallet/watchmarket/market/rate/cmc"
+	ratecoingecko "github.com/trustwallet/watchmarket/market/rate/coingecko"
+	ratecompound "github.com/trustwallet/watchmarket/market/rate/compound"
+	ratefixer "github.com/trustwallet/watchmarket/market/rate/fixer"
 	"github.com/trustwallet/watchmarket/storage"
 )
 
@@ -13,7 +23,9 @@ const (
 )
 
 var (
-	cache    *storage.Storage
+	cache         *storage.Storage
+	rateProviders *rateprovider.Providers
+	marketProviders *marketprovider.Providers
 )
 
 func init() {
@@ -23,10 +35,59 @@ func init() {
 
 	redisHost := viper.GetString("storage.redis")
 	cache = internal.InitRedis(redisHost)
+
+	rateProviders = &rateprovider.Providers{
+		// Add Market Quote Providers:
+		0: ratecmc.InitRate(
+			viper.GetString("market.cmc.api"),
+			viper.GetString("market.cmc.api_key"),
+			viper.GetString("market.cmc.map_url"),
+			viper.GetString("market.rate_update_time"),
+		),
+		1: ratefixer.InitRate(
+			viper.GetString("market.fixer.api"),
+			viper.GetString("market.fixer.api_key"),
+			viper.GetString("market.fixer.rate_update_time"),
+		),
+		2: ratecompound.InitRate(
+			viper.GetString("market.compound.api"),
+			viper.GetString("market.rate_update_time"),
+		),
+		3: ratecoingecko.InitRate(
+			viper.GetString("market.coingecko.api"),
+			viper.GetString("market.rate_update_time"),
+		),
+	}
+
+	marketProviders = &marketprovider.Providers{
+		// Add Market Quote Providers:
+		0: marketcmc.InitMarket(
+			viper.GetString("market.cmc.api"),
+			viper.GetString("market.cmc.api_key"),
+			viper.GetString("market.cmc.map_url"),
+			viper.GetString("market.quote_update_time"),
+		),
+		1: marketcompound.InitMarket(
+			viper.GetString("market.compound.api"),
+			viper.GetString("market.quote_update_time"),
+		),
+		2: marketcoingecko.InitMarket(
+			viper.GetString("market.coingecko.api"),
+			viper.GetString("market.quote_update_time"),
+		),
+		3: marketdex.InitMarket(
+			viper.GetString("market.dex.api"),
+			viper.GetString("market.dex.quote_update_time"),
+		),
+	}
 }
 
 func main() {
-	market.InitRates(cache)
-	market.InitMarkets(cache)
+	rateCron := market.InitRates(cache, rateProviders)
+	defer rateCron.Stop()
+	rateCron.Start()
+	marketCron := market.InitMarkets(cache, marketProviders)
+	defer marketCron.Stop()
+	marketCron.Start()
 	<-make(chan struct{})
 }

--- a/market/market.go
+++ b/market/market.go
@@ -2,53 +2,28 @@ package market
 
 import (
 	"github.com/robfig/cron/v3"
-	"github.com/spf13/viper"
 	"github.com/trustwallet/blockatlas/pkg/errors"
 	"github.com/trustwallet/blockatlas/pkg/logger"
 	"github.com/trustwallet/watchmarket/market/market"
-	"github.com/trustwallet/watchmarket/market/market/cmc"
-	"github.com/trustwallet/watchmarket/market/market/coingecko"
-	"github.com/trustwallet/watchmarket/market/market/compound"
-	"github.com/trustwallet/watchmarket/market/market/dex"
 	"github.com/trustwallet/watchmarket/storage"
 )
 
 var marketProviders market.Providers
 
-func InitMarkets(storage storage.Market) {
-	marketProviders = market.Providers{
-		// Add Market Quote Providers:
-		0: cmc.InitMarket(
-			viper.GetString("market.cmc.api"),
-			viper.GetString("market.cmc.api_key"),
-			viper.GetString("market.cmc.map_url"),
-			viper.GetString("market.quote_update_time"),
-		),
-		1: compound.InitMarket(
-			viper.GetString("market.compound.api"),
-			viper.GetString("market.quote_update_time"),
-		),
-		2: coingecko.InitMarket(
-			viper.GetString("market.coingecko.api"),
-			viper.GetString("market.quote_update_time"),
-		),
-		3: dex.InitMarket(
-			viper.GetString("market.dex.api"),
-			viper.GetString("market.dex.quote_update_time"),
-		),
-	}
-	addMarkets(storage, marketProviders)
+func InitMarkets(storage storage.Market, providers *market.Providers) *cron.Cron {
+	marketProviders = *providers
+	return scheduleMarkets(storage, marketProviders)
 }
 
-func addMarkets(storage storage.Market, ps market.Providers) {
+func scheduleMarkets(storage storage.Market, ps market.Providers) *cron.Cron {
 	c := cron.New()
 	for _, p := range ps {
 		scheduleTasks(storage, p, c)
 	}
-	c.Start()
+	return c
 }
 
-func runMarket(storage storage.Market, p market.Provider) error {
+func runMarket(storage storage.Market, p market.MarketProvider) error {
 	data, err := p.GetData()
 	if err != nil {
 		return errors.E(err, "GetData")

--- a/market/market/cmc/cmc.go
+++ b/market/market/cmc/cmc.go
@@ -16,7 +16,7 @@ type Market struct {
 	client *cmc.Client
 }
 
-func InitMarket(api string, apiKey string, mapApi string, updateTime string) market.Provider {
+func InitMarket(api string, apiKey string, mapApi string, updateTime string) market.MarketProvider {
 	m := &Market{
 		Market: market.Market{
 			Id:         id,

--- a/market/market/coingecko/coingecko.go
+++ b/market/market/coingecko/coingecko.go
@@ -19,7 +19,7 @@ type Market struct {
 	market.Market
 }
 
-func InitMarket(api, updateTime string) market.Provider {
+func InitMarket(api, updateTime string) market.MarketProvider {
 	m := &Market{
 		client: coingecko.NewClient(api),
 		Market: market.Market{

--- a/market/market/compound/compound.go
+++ b/market/market/compound/compound.go
@@ -17,7 +17,7 @@ type Market struct {
 	client *c.Client
 }
 
-func InitMarket(api string, updateTime string) market.Provider {
+func InitMarket(api string, updateTime string) market.MarketProvider {
 	m := &Market{
 		Market: market.Market{
 			Id:         id,

--- a/market/market/dex/dex.go
+++ b/market/market/dex/dex.go
@@ -22,7 +22,7 @@ type Market struct {
 	blockatlas.Request
 }
 
-func InitMarket(api string, updateTime string) market.Provider {
+func InitMarket(api string, updateTime string) market.MarketProvider {
 	m := &Market{
 		Market: market.Market{
 			Id:         id,

--- a/market/market/marketprovider.go
+++ b/market/market/marketprovider.go
@@ -5,7 +5,7 @@ import (
 	"github.com/trustwallet/watchmarket/storage"
 )
 
-type Provider interface {
+type MarketProvider interface {
 	Init(storage.Market) error
 	GetId() string
 	GetUpdateTime() string
@@ -13,7 +13,7 @@ type Provider interface {
 	GetLogType() string
 }
 
-type Providers map[int]Provider
+type Providers map[int]MarketProvider
 
 func (ps Providers) GetPriority(providerId string) int {
 	for priority, provider := range ps {

--- a/market/market_test.go
+++ b/market/market_test.go
@@ -1,0 +1,108 @@
+package market
+
+import (
+	"errors"
+	"fmt"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/trustwallet/blockatlas/coin"
+	"github.com/trustwallet/watchmarket/internal"
+	"github.com/trustwallet/watchmarket/market/market"
+	"github.com/trustwallet/watchmarket/market/rate"
+	rateprovider "github.com/trustwallet/watchmarket/mocks/market/rate"
+	marketprovider "github.com/trustwallet/watchmarket/mocks/market/market"
+	"github.com/trustwallet/watchmarket/pkg/watchmarket"
+	"testing"
+	"time"
+)
+
+func TestMarketObserver(t *testing.T) {
+	// Setup
+	s := setupRedis(t)
+	defer s.Close()
+
+	cache := internal.InitRedis(fmt.Sprintf("redis://%s", s.Addr()))
+
+	mockRateProvider := &rateprovider.RateProvider{}
+	mockRateProvider.On("Init", mock.AnythingOfType("*storage.Storage")).Return(nil)
+	mockRateProvider.On("GetUpdateTime").Return("5m")
+	mockRateProvider.On("GetLogType").Return("market-rate")
+	mockRateProvider.On("GetId").Return("coingecko")
+	testRate := watchmarket.Rate{
+		Currency:         "USD",
+		Rate:             1.0,
+		Timestamp:        time.Now().Unix(),
+		PercentChange24h: nil,
+		Provider:         "coingecko",
+	}
+	mockRateProvider.On("FetchLatestRates").Return(watchmarket.Rates{testRate}, nil)
+	rateProviders := &rate.Providers{
+		0: mockRateProvider,
+	}
+
+	mockMarketProvider := &marketprovider.MarketProvider{}
+	mockMarketProvider.On("Init", mock.AnythingOfType("*storage.Storage")).Return(nil)
+	mockMarketProvider.On("GetUpdateTime").Return("5m")
+	mockMarketProvider.On("GetLogType").Return("market-data")
+	mockMarketProvider.On("GetId").Return("coingecko")
+	coinObj, ok := coin.Coins[60] // ETH
+	if !ok {
+		t.Fatal(errors.New("coin does not exist"))
+	}
+	testTicker := watchmarket.Ticker{
+		Coin:       coinObj.ID,
+		CoinName:   coinObj.Symbol,
+		TokenId:    "",
+		CoinType:   "tbd",
+		Price:      watchmarket.TickerPrice{
+			Value:     50,
+			Change24h: 0,
+			Currency:  "USD",
+			Provider:  "coingecko",
+		},
+		LastUpdate: time.Now(),
+	}
+	mockMarketProvider.On("GetData").Return(watchmarket.Tickers{&testTicker}, nil)
+	marketProviders := &market.Providers{
+		0: mockMarketProvider,
+	}
+
+	// Act
+	rateCron := InitRates(cache, rateProviders)
+	defer rateCron.Stop()
+	rateCron.Start()
+	marketCron := InitMarkets(cache, marketProviders)
+	defer marketCron.Stop()
+	marketCron.Start()
+
+	// Verify
+	resultRate, err := cache.GetRate("USD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resultTicker, err := cache.GetTicker("ETH", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, resultRate.Currency, testRate.Currency)
+	assert.Equal(t, resultRate.Provider, testRate.Provider)
+	assert.Equal(t, resultRate.Rate, testRate.Rate)
+	assert.Equal(t, resultRate.PercentChange24h, testRate.PercentChange24h)
+	assert.Equal(t, resultTicker.TokenId, testTicker.TokenId)
+	assert.Equal(t, resultTicker.Coin, testTicker.Coin)
+	assert.Equal(t, resultTicker.CoinName, testTicker.CoinName)
+	assert.Equal(t, resultTicker.CoinType, testTicker.CoinType)
+	assert.Equal(t, resultTicker.Price.Provider, testTicker.Price.Provider)
+	assert.Equal(t, resultTicker.Price.Currency, testTicker.Price.Currency)
+	assert.Equal(t, resultTicker.Price.Provider, testTicker.Price.Provider)
+	assert.Equal(t, resultTicker.Price.Value, testTicker.Price.Value)
+}
+
+func setupRedis(t *testing.T) *miniredis.Miniredis {
+	s, err := miniredis.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}

--- a/market/rate/cmc/cmc.go
+++ b/market/rate/cmc/cmc.go
@@ -17,7 +17,7 @@ type Cmc struct {
 	client *cmc.Client
 }
 
-func InitRate(api string, apiKey string, mapApi string, updateTime string) rate.Provider {
+func InitRate(api string, apiKey string, mapApi string, updateTime string) rate.RateProvider {
 	cmc := &Cmc{
 		Rate: rate.Rate{
 			Id:         id,

--- a/market/rate/coingecko/coingecko.go
+++ b/market/rate/coingecko/coingecko.go
@@ -17,7 +17,7 @@ type Coingecko struct {
 	rate.Rate
 }
 
-func InitRate(api string, updateTime string) rate.Provider {
+func InitRate(api string, updateTime string) rate.RateProvider {
 	return &Coingecko{
 		client: coingecko.NewClient(api),
 		Rate: rate.Rate{

--- a/market/rate/compound/compound.go
+++ b/market/rate/compound/compound.go
@@ -17,7 +17,7 @@ type Compound struct {
 	client *c.Client
 }
 
-func InitRate(api string, updateTime string) rate.Provider {
+func InitRate(api string, updateTime string) rate.RateProvider {
 	return &Compound{
 		Rate: rate.Rate{
 			Id:         compound,

--- a/market/rate/fixer/fixer.go
+++ b/market/rate/fixer/fixer.go
@@ -17,7 +17,7 @@ type Fixer struct {
 	blockatlas.Request
 }
 
-func InitRate(api string, apiKey string, updateTime string) rate.Provider {
+func InitRate(api string, apiKey string, updateTime string) rate.RateProvider {
 	return &Fixer{
 		Rate: rate.Rate{
 			Id:         id,

--- a/market/rate/rateprovider.go
+++ b/market/rate/rateprovider.go
@@ -5,7 +5,7 @@ import (
 	"github.com/trustwallet/watchmarket/storage"
 )
 
-type Provider interface {
+type RateProvider interface {
 	Init(storage.Market) error
 	FetchLatestRates() (watchmarket.Rates, error)
 	GetUpdateTime() string
@@ -13,7 +13,7 @@ type Provider interface {
 	GetLogType() string
 }
 
-type Providers map[int]Provider
+type Providers map[int]RateProvider
 
 func (ps Providers) GetPriority(providerId string) int {
 	for priority, provider := range ps {

--- a/market/worker.go
+++ b/market/worker.go
@@ -66,9 +66,9 @@ func scheduleTasks(storage storage.Market, md Provider, c *cron.Cron) {
 func run(storage storage.Market, md Provider) error {
 	logger.Info("Starting market data task...", logger.Params{"Type": md.GetLogType(), "Market": md.GetId()})
 	switch m := md.(type) {
-	case market.Provider:
+	case market.MarketProvider:
 		return runMarket(storage, m)
-	case rate.Provider:
+	case rate.RateProvider:
 		return runRate(storage, m)
 	}
 	return errors.E("invalid market interface")

--- a/storage/market_test.go
+++ b/storage/market_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/trustwallet/watchmarket/mocks"
+	"github.com/trustwallet/watchmarket/mocks/storage"
 	"github.com/trustwallet/watchmarket/pkg/watchmarket"
 	"testing"
 	"time"


### PR DESCRIPTION
* Adds a basic functional test for the market observer using [Miniredis](https://github.com/alicebob/miniredis)
* Refactors observer initializer:
   * to take a list of providers from its consumer
   * return a `Cron` object that can be started/stopped by the consumer
* Renames conflicting `Provider` interfaces to support mock generation with mockery
* Moves generated mocks into according subdirectories to avoid import cycles