### PR TITLE
Fix observer jobs to shutdown gracefully

### DIFF
--- a/cmd/market_observer/main.go
+++ b/cmd/market_observer/main.go
@@ -89,5 +89,6 @@ func main() {
 	marketCron := market.InitMarkets(cache, marketProviders)
 	defer marketCron.Stop()
 	marketCron.Start()
-	<-make(chan struct{})
+	internal.WaitingForExitSignal()
+	logger.Info("Waiting for all observer jobs to stop")
 }

--- a/internal/shutdown.go
+++ b/internal/shutdown.go
@@ -25,13 +25,6 @@ func SetupGracefulShutdown(port string, engine *gin.Engine) {
 		}
 	}()
 
-	signalForExit := make(chan os.Signal, 1)
-	signal.Notify(signalForExit,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT)
-
 	go func() {
 		if err := server.ListenAndServe(); err != nil {
 			logger.Fatal("Application failed", err)
@@ -39,7 +32,17 @@ func SetupGracefulShutdown(port string, engine *gin.Engine) {
 	}()
 	logger.Info("Running application", logger.Params{"bind": port})
 
+	WaitingForExitSignal()
+	logger.Info("Waiting for all jobs to stop")
+}
+
+func WaitingForExitSignal() {
+	signalForExit := make(chan os.Signal, 1)
+	signal.Notify(signalForExit,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT)
 	stop := <-signalForExit
 	logger.Info("Stop signal Received", stop)
-	logger.Info("Waiting for all jobs to stop")
 }


### PR DESCRIPTION
Small fix for [#37 ](https://github.com/trustwallet/watchmarket/issues/37).

Further improvement ideas:
- Allow the logs to be more verbose or specific (adding [ComponentName] before level would help to differentiate shutdown logs for example.
- Ability to start/shutdown component selectively
- Migrate from makefile to cli command (?)

