### PR TITLE
Fixed: Coin info API doesn't properly implement HTTP protocol (Fixes #44)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,8 @@ generate-mocks:
 	@-$(GOBIN)/mockery -dir storage -output mocks/storage -name ProviderList
 	@-$(GOBIN)/mockery -dir market/rate -output mocks/market/rate -name RateProvider
 	@-$(GOBIN)/mockery -dir market/market -output mocks/market/market -name MarketProvider
+	@-$(GOBIN)/mockery -dir market/chart -output mocks/market/chart -name ChartProvider
+	@-$(GOBIN)/mockery -dir services/assets -output mocks/services/assets -name AssetClient
 
 ## test: Run all unit tests.
 test: go-install-mockery generate-mocks go-test

--- a/api/api.go
+++ b/api/api.go
@@ -2,11 +2,13 @@ package api
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/trustwallet/watchmarket/market"
+	"github.com/trustwallet/watchmarket/services/assets"
 	"github.com/trustwallet/watchmarket/storage"
 )
 
-func Bootstrap(engine *gin.Engine, market storage.Market) {
+func Bootstrap(engine *gin.Engine, market storage.Market, charts *market.Charts, ac assets.AssetClient) {
 	engine.GET("/", GetRoot)
 	marketAPI := engine.Group("/v1/market")
-	SetupMarketAPI(marketAPI, market)
+	SetupMarketAPI(marketAPI, market, charts, ac)
 }

--- a/api/marketdata.go
+++ b/api/marketdata.go
@@ -33,13 +33,13 @@ type Coin struct {
 	TokenId  string              `json:"token_id,omitempty"`
 }
 
-func SetupMarketAPI(router gin.IRouter, db storage.Market) {
+func SetupMarketAPI(router gin.IRouter, db storage.Market, charts *market.Charts, ac assets.AssetClient) {
 	router.Use(ginutils.TokenAuthMiddleware(viper.GetString("market.auth")))
 	// Ticker
 	router.POST("/ticker", getTickersHandler(db))
 	// Charts
 	router.GET("/charts", getChartsHandler())
-	router.GET("/info", getCoinInfoHandler())
+	router.GET("/info", getCoinInfoHandler(charts, ac))
 }
 
 // @Summary Get ticker values for a specific market
@@ -173,26 +173,39 @@ func getChartsHandler() func(c *gin.Context) {
 // @Param currency query string false "The currency to show coin info in" default(USD)
 // @Success 200 {object} watchmarket.ChartCoinInfo
 // @Router /v1/market/info [get]
-func getCoinInfoHandler() func(c *gin.Context) {
-	var charts = market.InitCharts()
+func getCoinInfoHandler(charts *market.Charts, ac assets.AssetClient) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		coinQuery := c.Query("coin")
+		if len(coinQuery) == 0 {
+			ginutils.RenderError(c, http.StatusBadRequest, "No coin provided")
+			return
+		}
+
 		coinId, err := strconv.Atoi(coinQuery)
 		if err != nil {
-			ginutils.RenderError(c, http.StatusBadRequest, "Invalid coin")
+			ginutils.RenderError(c, http.StatusBadRequest, "Invalid coin provided")
 			return
 		}
 
 		token := c.Query("token")
 		currency := c.DefaultQuery("currency", watchmarket.DefaultCurrency)
 		chart, err := charts.GetCoinInfo(uint(coinId), token, currency)
-		if err != nil {
-			logger.Error(err, "Failed to retrieve coin info", logger.Params{"coin": coinId, "currency": currency})
+		if err == watchmarket.ErrNotFound {
+			ginutils.RenderError(c, http.StatusNotFound, fmt.Sprintf("Coin info for coin id %d (token: %s, currency: %s) not found", coinId, token, currency))
+			return
+		} else if err != nil {
+			logger.Error(err, "Failed to retrieve coin info", logger.Params{"coinId": coinId, "token": token, "currency": currency})
+			ginutils.RenderError(c, http.StatusInternalServerError, "Failed to retrieve coin info")
+			return
 		}
-		chart.Info, err = assets.GetCoinInfo(coinId, token)
-		if err != nil {
-			logger.Error(err, "Failed to retrieve coin info", logger.Params{"coin": coinId, "currency": currency})
-			ginutils.RenderError(c, http.StatusInternalServerError, err.Error())
+
+		chart.Info, err = ac.GetCoinInfo(coinId, token)
+		if err == watchmarket.ErrNotFound {
+			ginutils.RenderError(c, http.StatusNotFound, fmt.Sprintf("Coin assets for coin id %d (token: %s) not found", coinId, token))
+			return
+		} else if err != nil {
+			logger.Error(err, "Failed to retrieve coin assets", logger.Params{"coinId": coinId, "token": token})
+			ginutils.RenderError(c, http.StatusInternalServerError, "Failed to retrieve coin assets")
 			return
 		}
 		ginutils.RenderSuccess(c, chart)

--- a/cmd/market_api/main.go
+++ b/cmd/market_api/main.go
@@ -3,11 +3,14 @@ package main
 import (
 	sentrygin "github.com/getsentry/sentry-go/gin"
 	"github.com/gin-gonic/gin"
+	"github.com/go-resty/resty/v2"
 	"github.com/spf13/viper"
 	"github.com/trustwallet/blockatlas/pkg/logger"
 	"github.com/trustwallet/watchmarket/api"
 	_ "github.com/trustwallet/watchmarket/docs"
 	"github.com/trustwallet/watchmarket/internal"
+	"github.com/trustwallet/watchmarket/market"
+	"github.com/trustwallet/watchmarket/services/assets"
 	"github.com/trustwallet/watchmarket/storage"
 )
 
@@ -35,6 +38,6 @@ func init() {
 }
 
 func main() {
-	api.Bootstrap(engine, cache)
+	api.Bootstrap(engine, cache, market.InitCharts(), &assets.HttpAssetClient{HttpClient: resty.New()})
 	internal.SetupGracefulShutdown(port, engine)
 }

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,17 @@ go 1.13
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/alicebob/miniredis/v2 v2.11.2
+	github.com/aristanetworks/glog v0.0.0-20191112221043-67e8567f59f3 // indirect
+	github.com/aristanetworks/goarista v0.0.0-20190219163901-728bce664cf5
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/getsentry/sentry-go v0.5.1
 	github.com/gin-gonic/gin v1.5.0
 	github.com/go-redis/redis v6.15.6+incompatible
+	github.com/go-resty/resty/v2 v2.2.0
+	github.com/jarcoal/httpmock v1.0.4
+	github.com/magiconair/properties v1.8.1
+	github.com/openconfig/reference v0.0.0-20190727015836-8dfd928c9696 // indirect
+	github.com/prometheus/common v0.9.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.5.1

--- a/market/chart/chartprovider.go
+++ b/market/chart/chartprovider.go
@@ -4,15 +4,15 @@ import (
 	"github.com/trustwallet/watchmarket/pkg/watchmarket"
 )
 
-type Provider interface {
+type ChartProvider interface {
 	GetId() string
 	GetChartData(coin uint, token string, currency string, timeStart int64) (watchmarket.ChartData, error)
 	GetCoinData(coin uint, token string, currency string) (watchmarket.ChartCoinInfo, error)
 }
 
-type Providers map[int]Provider
+type ChartProviders map[int]ChartProvider
 
-func (ps Providers) GetPriority(providerId string) int {
+func (ps ChartProviders) GetPriority(providerId string) int {
 	for priority, provider := range ps {
 		if provider.GetId() == providerId {
 			return priority

--- a/market/chart/cmc/cmc.go
+++ b/market/chart/cmc/cmc.go
@@ -20,7 +20,7 @@ type Chart struct {
 	widgetClient *cmc.WidgetClient
 }
 
-func InitChart(webApi string, widgetApi string, mapApi string) chart.Provider {
+func InitChart(webApi string, widgetApi string, mapApi string) chart.ChartProvider {
 	m := &Chart{
 		Chart: chart.Chart{
 			Id: id,

--- a/market/chart/coingecko/coingecko.go
+++ b/market/chart/coingecko/coingecko.go
@@ -19,7 +19,7 @@ type Chart struct {
 	client *coingecko.Client
 }
 
-func InitChart(api string) chart.Provider {
+func InitChart(api string) chart.ChartProvider {
 	m := &Chart{
 		Chart: chart.Chart{
 			Id: id,

--- a/market/charts.go
+++ b/market/charts.go
@@ -17,11 +17,11 @@ const (
 )
 
 type Charts struct {
-	chartProviders chart.Providers
+	ChartProviders chart.ChartProviders
 }
 
 func InitCharts() *Charts {
-	return &Charts{chart.Providers{
+	return &Charts{chart.ChartProviders{
 		0: cmc.InitChart(
 			viper.GetString("market.cmc.webapi"),
 			viper.GetString("market.cmc.widgetapi"),
@@ -36,8 +36,8 @@ func InitCharts() *Charts {
 func (c *Charts) GetChartData(coin uint, token string, currency string, timeStart int64, maxItems int) (watchmarket.ChartData, error) {
 	chartsData := watchmarket.ChartData{}
 	timeStart = numbers.Max(timeStart, minUnixTime)
-	for i := 0; i < len(c.chartProviders); i++ {
-		c := c.chartProviders[i]
+	for i := 0; i < len(c.ChartProviders); i++ {
+		c := c.ChartProviders[i]
 		charts, err := c.GetChartData(coin, token, currency, timeStart)
 		if err != nil {
 			continue
@@ -48,17 +48,19 @@ func (c *Charts) GetChartData(coin uint, token string, currency string, timeStar
 	return chartsData, errors.E("No chart data found", errors.Params{"coin": coin, "token": token})
 }
 
+
 func (c *Charts) GetCoinInfo(coin uint, token string, currency string) (watchmarket.ChartCoinInfo, error) {
 	coinInfoData := watchmarket.ChartCoinInfo{}
-	for i := 0; i < len(c.chartProviders); i++ {
-		c := c.chartProviders[i]
+	for i := 0; i < len(c.ChartProviders); i++ {
+		c := c.ChartProviders[i]
 		info, err := c.GetCoinData(coin, token, currency)
 		if err != nil {
 			continue
 		}
 		return info, nil
 	}
-	return coinInfoData, errors.E("No chart coin info data found", errors.Params{"coin": coin, "token": token})
+
+	return coinInfoData, watchmarket.ErrNotFound
 }
 
 func normalizePrices(prices []watchmarket.ChartPrice, maxItems int) (result []watchmarket.ChartPrice) {

--- a/services/assets/info_test.go
+++ b/services/assets/info_test.go
@@ -1,9 +1,66 @@
 package assets
 
 import (
+	"errors"
+	"github.com/go-resty/resty/v2"
+	"github.com/jarcoal/httpmock"
+	"github.com/magiconair/properties/assert"
 	"github.com/trustwallet/blockatlas/coin"
+	"github.com/trustwallet/watchmarket/pkg/watchmarket"
 	"testing"
 )
+
+func Test_GetCoinInfo(t *testing.T) {
+	type args struct {
+		c     coin.Coin
+		token string
+	}
+
+	httpClient := resty.New()
+	httpmock.ActivateNonDefault(httpClient.GetClient())
+	client := HttpAssetClient{HttpClient: httpClient}
+
+	mockEthCoinInfo := watchmarket.CoinInfo{
+		Name:             "Ethereum",
+		Website:          "https://ethereum.org/",
+		SourceCode:       "https://github.com/ethereum",
+		WhitePaper:       "https://github.com/ethereum/wiki/wiki/White-Paper",
+		Description:      "Open source platform to write and distribute decentralized applications.",
+		ShortDescription: "Open source platform to write and distribute decentralized applications.",
+		Explorers:        []watchmarket.Link{{Name: "Ethereum", Url: "https://etherscan.io/"}},
+		Socials:          []watchmarket.SocialLink{{Name: "Twitter",Url: "https://twitter.com/ethereum", Handle: "ethereum"}},
+		DataSource:       "crowd",
+	}
+
+	ethResponder, err := httpmock.NewJsonResponder(200, mockEthCoinInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpmock.RegisterResponder("GET", "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/info/info.json", ethResponder)
+	httpmock.RegisterResponder("GET", "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/info/info.json", httpmock.NewStringResponder(404, "Not Found"))
+	httpmock.RegisterResponder("GET", "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/vechain/info/info.json", httpmock.NewStringResponder(400, "Boom!"))
+
+	tests := []struct {
+		name string
+		args args
+		wantErr error
+		wantInfo watchmarket.CoinInfo
+	}{
+		{"test nominal", args{coin.Ethereum(), ""}, nil, mockEthCoinInfo},
+		{"test not found", args{coin.Binance(), ""}, watchmarket.ErrNotFound, watchmarket.CoinInfo{}},
+		{"test not found", args{coin.Vechain(), ""}, errors.New("Request to https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/vechain/info/info.json failed with HTTP 400: Boom!"), watchmarket.CoinInfo{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := client.GetCoinInfo(int(tt.args.c.ID), tt.args.token)
+			if err != nil {
+				assert.Equal(t, err, tt.wantErr)
+			} else {
+				assert.Equal(t, *info, tt.wantInfo)
+			}
+		})
+	}
+}
 
 func Test_getCoinInfoUrl(t *testing.T) {
 	type args struct {


### PR DESCRIPTION
Coininfo API doesn't implement HTTP Not Found and fails such requests with HTTP Internal Server Error instead.

The HTTP client used does not expose said errors.

Changes:
* Coininfo API now returns HTTP 404 when coin is not available
* Coininfo API does some more input validation and returns HTTP 400 when validations fail 
* Uses `resty` as HTTP client
* Removes HTTP level caching - potentially problematic but  #47 introduces app layer caching
* Introduces functional test for Coininfo API

Also adding the Codecov token to `.codecov.yml`. This should not be required when using Azure Pipelines and public repositories but it sometimes works and sometimes fails. Improvement would be to move the token to the Azure environment. I see no security concern with adding this here.

#### Testing
Ran `newman` tests and `make test`