### PR TITLE
Removes cron-level retries

### DIFF
--- a/market/market_test.go
+++ b/market/market_test.go
@@ -76,6 +76,8 @@ func TestMarketObserver(t *testing.T) {
 	defer marketCron.Stop()
 	marketCron.Start()
 
+	time.Sleep(100 * time.Millisecond) // Allow cron to process
+
 	// Verify
 	resultRate, err := cache.GetRate("USD")
 	if err != nil {

--- a/market/rates.go
+++ b/market/rates.go
@@ -2,7 +2,6 @@ package market
 
 import (
 	"github.com/robfig/cron/v3"
-	"github.com/trustwallet/blockatlas/pkg/errors"
 	"github.com/trustwallet/blockatlas/pkg/logger"
 	"github.com/trustwallet/watchmarket/market/rate"
 	"github.com/trustwallet/watchmarket/storage"
@@ -23,12 +22,12 @@ func scheduleRates(storage storage.Market, rates rate.Providers) *cron.Cron {
 	return c
 }
 
-func runRate(storage storage.Market, p rate.RateProvider) error {
+func runRate(storage storage.Market, p rate.RateProvider) {
 	rates, err := p.FetchLatestRates()
 	if err != nil {
-		return errors.E(err, "FetchLatestRates")
+		logger.Error("Failed to fetch rates", logger.Params{"error": err, "provider": p.GetId()})
+		return
 	}
 	results := storage.SaveRates(rates, rateProviders)
 	logger.Info("Done fetching latest rates", logger.Params{"numFetchedRates": len(rates), "provider": p.GetId(), "results": results})
-	return nil
 }


### PR DESCRIPTION
* it is not clear why we would have cron-level exponential backoff - by definition crons retry after the specified interval
* retries were based on the contract of any `error` causing a retry. This is wrong as some errors may not be retryable
* Retrying should arguably be on another layer e.g. add retries to explorer API clients if the API returns HTTP5XX
* the retry contract of returning errors was not cleanly implemented - some errors were swallowed and some were without a sensical pattern