### PR TITLE
Remove hardcoded token from marketdata

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -254,11 +254,11 @@ func TestCoinInfo(t *testing.T) {
 		},
 		{
 			name:           "test coin info not found",
-			requestUrl:     fmt.Sprintf("%s/v1/market/info?coin=500&token=ETHToken", server.URL),
+			requestUrl:     fmt.Sprintf("%s/v1/market/info?coin=1000&token=ETHToken", server.URL),
 			requestMethod:  "GET",
 			requestBody:    "",
-			expectedStatus: 404,
-			expectedBody:   "{\"code\":404,\"error\":\"Coin info for coin id 500 (token: ETHToken, currency: USD) not found\"}",
+			expectedStatus: 200,
+			expectedBody:   "",
 		},
 		{
 			name:           "test coin assets not found",
@@ -281,7 +281,6 @@ func TestCoinInfo(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
 			assert.Equal(t, parseJson(t, responseBytes), parseJson(t, []byte(tt.expectedBody)))
 		})
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -254,11 +254,11 @@ func TestCoinInfo(t *testing.T) {
 		},
 		{
 			name:           "test coin info not found",
-			requestUrl:     fmt.Sprintf("%s/v1/market/info?coin=1000&token=ETHToken", server.URL),
+			requestUrl:     fmt.Sprintf("%s/v1/market/info?coin=500&token=ETHToken", server.URL),
 			requestMethod:  "GET",
 			requestBody:    "",
 			expectedStatus: 200,
-			expectedBody:   "",
+			expectedBody:   "{\"circulating_supply\": 0, \"info\": {}, \"market_cap\": 0, \"total_supply\": 0, \"volume_24\": 0}",
 		},
 		{
 			name:           "test coin assets not found",
@@ -306,6 +306,15 @@ func setupRedis(t *testing.T) *miniredis.Miniredis {
 func getAssetClientMock() assets.AssetClient {
 	client := &mockassetprovider.AssetClient{}
 	client.On("GetCoinInfo", 60, "ETHToken").Return(&watchmarket.CoinInfo{
+		Name:             "",
+		Website:          "",
+		SourceCode:       "",
+		WhitePaper:       "",
+		Description:      "",
+		ShortDescription: "",
+		DataSource:       "",
+	}, nil)
+	client.On("GetCoinInfo", 500, "ETHToken").Return(&watchmarket.CoinInfo{
 		Name:             "",
 		Website:          "",
 		SourceCode:       "",

--- a/api/marketdata.go
+++ b/api/marketdata.go
@@ -205,14 +205,10 @@ func getCoinInfoHandler(charts *market.Charts, ac assets.AssetClient) func(c *gi
 		token := c.Query("token")
 		currency := c.DefaultQuery("currency", watchmarket.DefaultCurrency)
 		chart, err := charts.GetCoinInfo(uint(coinId), token, currency)
-		// TODO: cover special casing of TWT token in tests
-		if err == watchmarket.ErrNotFound && token != tokenTWT {
-			ginutils.RenderError(c, http.StatusNotFound, fmt.Sprintf("Coin info for coin id %d (token: %s, currency: %s) not found", coinId, token, currency))
-			return
-		} else if err != nil && token != tokenTWT {
-			logger.Error(err, "Failed to retrieve coin info", logger.Params{"coinId": coinId, "token": token, "currency": currency})
-			ginutils.RenderError(c, http.StatusInternalServerError, "Failed to retrieve coin info")
-			return
+		if err == watchmarket.ErrNotFound {
+			logger.Info(fmt.Sprintf("Coin info for coin id %d (token: %s, currency: %s) not found", coinId, token, currency))
+		} else if err != nil {
+			logger.Info(err, "Failed to retrieve coin info", logger.Params{"coinId": coinId, "token": token, "currency": currency})
 		}
 
 		chart.Info, err = ac.GetCoinInfo(coinId, token)


### PR DESCRIPTION
Remove hardcoded TWT token
Change api behavior, so we will return chart.info even if we will not have chart for it