### PR TITLE
adding TRC20 LVH

### DIFF
--- a/services/markets/coinmarketcap/mapping.go
+++ b/services/markets/coinmarketcap/mapping.go
@@ -13019,6 +13019,12 @@ const Mapping = `[
         "id": 6495
     },
     {
+        "coin": 195,
+        "type": "token",
+        "token_id": "TGbhcodQ1jRWB3ZywmfwsRTh4rwbiL2mzh",
+        "id": 6495
+    },
+    {
         "coin": 60,
         "type": "token",
         "token_id": "0x8DB90E3e7D04C875a51997092f9178FCac9DefdB",


### PR DESCRIPTION
I checked CMC, TRC10 price is being tracked: https://coinmarketcap.com/currencies/lovehearts/
https://tronscan.org/#/token/1000451
But CG tracks the TRC20 toke: https://www.coingecko.com/en/coins/lovehearts
https://tronscan.org/#/token20/TGbhcodQ1jRWB3ZywmfwsRTh4rwbiL2mzh

Adding the TRC20 token contract.