### PR TITLE
adding ERC20 AAVE-NEW

### DIFF
--- a/services/markets/coinmarketcap/mapping.go
+++ b/services/markets/coinmarketcap/mapping.go
@@ -13518,6 +13518,12 @@ const Mapping = `[
         "id": 7242
     },
     {
+        "coin": 60,
+        "type": "token",
+        "token_id": "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
+        "id": 7278
+    },
+    {
         "coin": 20000714,
         "type": "token",
         "token_id": "0xcF6BB5389c92Bdda8a3747Ddb454cB7a64626C63",


### PR DESCRIPTION
LEND has migrated to AAVE at a rate of 100 LEND per 1 AAVE.
https://medium.com/aave/migration-and-staking-101-fe8fda3e2a30
https://coinmarketcap.com/currencies/aave-new/
https://etherscan.io/address/0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9