### PR TITLE
update ERC20 SEELE

### DIFF
--- a/services/markets/coinmarketcap/mapping.go
+++ b/services/markets/coinmarketcap/mapping.go
@@ -4271,7 +4271,7 @@ const Mapping = `[
     {
         "coin": 60,
         "type": "token",
-        "token_id": "0xB1eeF147028E9f480DbC5ccaA3277D417D1b85F0",
+        "token_id": "0xB1e93236ab6073fdAC58adA5564897177D4bcC43",
         "id": 2830
     },
     {


### PR DESCRIPTION
Seele has just completed a chain swap where the contract address migrated from 0xb1eef147028e9f480dbc5ccaa3277d417d1b85f0 to 0xb1e93236ab6073fdac58ada5564897177d4bcc43
New contract: https://etherscan.io/address/0xb1e93236ab6073fdac58ada5564897177d4bcc43