### PR TITLE
Fix unstable tickers_test.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,8 +26,8 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/swaggo/gin-swagger v1.2.0
 	github.com/swaggo/swag v1.6.7
-	github.com/trustwallet/golibs v0.0.35
-	github.com/trustwallet/golibs/network v0.0.0-20201217160111-1a8423bbcaa1
+	github.com/trustwallet/golibs v0.1.0
+	github.com/trustwallet/golibs/network v0.0.0-20210124080535-8638b407c4ab
 	golang.org/x/tools v0.0.0-20200513175351-0951661448da // indirect
 	gorm.io/driver/postgres v1.0.6
 	gorm.io/gorm v1.20.11

--- a/go.sum
+++ b/go.sum
@@ -562,8 +562,6 @@ github.com/trustwallet/golibs v0.0.35 h1:VqWInO5s4Zg6XyCmqro8/xrEViOedZ3oYtBq/kn
 github.com/trustwallet/golibs v0.0.35/go.mod h1:VI0APImKAYxvJ8MnMD6aHSKvnArXUd3NgNEghX5P+K8=
 github.com/trustwallet/golibs v0.1.0 h1:uo52Hy3WTfGkkd1Y7ti5Hl6BPhvudXG5BlmhBtgtQ6Y=
 github.com/trustwallet/golibs v0.1.0/go.mod h1:SQ3mijAuOTX9GRyaqph3NY2ox04JD5WQ6PkWqX2NB8w=
-github.com/trustwallet/golibs/network v0.0.0-20201217160111-1a8423bbcaa1 h1:x2vE676o4hhpq0eq6UF1P3PGFFF1nwfuARKHHd8nLvQ=
-github.com/trustwallet/golibs/network v0.0.0-20201217160111-1a8423bbcaa1/go.mod h1:RMMyjp4qUcVhWidjE+XYzQgOtSXuhIKSB5pnLCA3WqY=
 github.com/trustwallet/golibs/network v0.0.0-20210124080535-8638b407c4ab h1:djqS58OXHs6tkRoCyuPnMu5q5woQj/1bxUFnSN0Xlew=
 github.com/trustwallet/golibs/network v0.0.0-20210124080535-8638b407c4ab/go.mod h1:LDMLFnOnwmC30WuCCIJ56TWeXxwCVcrMFJYeC6GEnxY=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/go.sum
+++ b/go.sum
@@ -560,8 +560,12 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustwallet/golibs v0.0.35 h1:VqWInO5s4Zg6XyCmqro8/xrEViOedZ3oYtBq/kn4fBg=
 github.com/trustwallet/golibs v0.0.35/go.mod h1:VI0APImKAYxvJ8MnMD6aHSKvnArXUd3NgNEghX5P+K8=
+github.com/trustwallet/golibs v0.1.0 h1:uo52Hy3WTfGkkd1Y7ti5Hl6BPhvudXG5BlmhBtgtQ6Y=
+github.com/trustwallet/golibs v0.1.0/go.mod h1:SQ3mijAuOTX9GRyaqph3NY2ox04JD5WQ6PkWqX2NB8w=
 github.com/trustwallet/golibs/network v0.0.0-20201217160111-1a8423bbcaa1 h1:x2vE676o4hhpq0eq6UF1P3PGFFF1nwfuARKHHd8nLvQ=
 github.com/trustwallet/golibs/network v0.0.0-20201217160111-1a8423bbcaa1/go.mod h1:RMMyjp4qUcVhWidjE+XYzQgOtSXuhIKSB5pnLCA3WqY=
+github.com/trustwallet/golibs/network v0.0.0-20210124080535-8638b407c4ab h1:djqS58OXHs6tkRoCyuPnMu5q5woQj/1bxUFnSN0Xlew=
+github.com/trustwallet/golibs/network v0.0.0-20210124080535-8638b407c4ab/go.mod h1:LDMLFnOnwmC30WuCCIJ56TWeXxwCVcrMFJYeC6GEnxY=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.5-pre/go.mod h1:FwP/aQVg39TXzItUBMwnWp9T9gPQnXw4Poh4/oBQZ/0=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
@@ -656,6 +660,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201216054612-986b41b23924 h1:QsnDpLLOKwHBBDa8nDws4DYNc/ryVW2vCpxCs09d4PY=
 golang.org/x/net v0.0.0-20201216054612-986b41b23924/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/services/markets/binancedex/tickers.go
+++ b/services/markets/binancedex/tickers.go
@@ -65,7 +65,7 @@ func normalizeTicker(price CoinPrice, provider string) (watchmarket.Ticker, erro
 	}
 
 	t = watchmarket.Ticker{
-		Coin:     coin.BNB,
+		Coin:     coin.BINANCE,
 		CoinName: BNBAsset,
 		CoinType: watchmarket.Token,
 		TokenId:  strings.ToLower(tokenId),

--- a/services/markets/coingecko/mocks/tickers.json
+++ b/services/markets/coingecko/mocks/tickers.json
@@ -28,7 +28,7 @@
     "market_cap": 22851909019
   },
   {
-    "coin": 10000714,
+    "coin": 20000714,
     "coin_name": "BNB",
     "type": "coin",
     "price": {

--- a/services/markets/coingecko/tickers.go
+++ b/services/markets/coingecko/tickers.go
@@ -1,9 +1,9 @@
 package coingecko
 
 import (
-	"strings"
-
 	"errors"
+	"sort"
+	"strings"
 
 	"github.com/trustwallet/golibs/coin"
 	"github.com/trustwallet/watchmarket/pkg/watchmarket"
@@ -202,7 +202,15 @@ func isBasicCoin(symbol string) bool {
 }
 
 func getCoinBySymbol(symbol string) coin.Coin {
+	ids := []int{}
 	for _, c := range coin.Coins {
+		ids = append(ids, int(c.ID))
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i] > ids[j]
+	})
+	for _, id := range ids {
+		c := coin.Coins[uint(id)]
 		if strings.EqualFold(c.Symbol, symbol) {
 			return c
 		}


### PR DESCRIPTION
Changes:

1. update golibs/coin package to remove legacy bsc
2. sort coins in `getCoinBySymbol`