### PR TITLE
Update Bitcoin Standard Hashrate Token (BTCST) BEP20 pricing

### DIFF
--- a/services/markets/coinmarketcap/mapping.go
+++ b/services/markets/coinmarketcap/mapping.go
@@ -14503,12 +14503,6 @@ const Mapping = `[
     {
         "coin": 20000714,
         "type": "token",
-        "token_id": "0x78650B139471520656b9E7aA7A5e9276814a38e9",
-        "id": 8210
-    },
-    {
-        "coin": 20000714,
-        "type": "token",
         "token_id": "0x190b589cf9Fb8DDEabBFeae36a813FFb2A702454",
         "id": 8219
     },
@@ -14601,5 +14595,11 @@ const Mapping = `[
         "type": "token",
         "token_id": "0x5d3AfBA1924aD748776E4Ca62213BF7acf39d773",
         "id": 8877
+    },
+    {
+        "coin": 20000714,
+        "type": "token",
+        "token_id": "0x78650B139471520656b9E7aA7A5e9276814a38e9",
+        "id": 8891
     }
 ]`


### PR DESCRIPTION
https://btcst.medium.com/btcst-to-implement-results-of-stp-4-1-10-redenomination-the-week-of-march-15-872c9ea3d5b7

https://bscscan.com/address/0x78650b139471520656b9e7aa7a5e9276814a38e9

https://coinmarketcap.com/currencies/btc-standard-hashrate-token/

https://www.coingecko.com/en/coins/btc-standard-hashrate-token